### PR TITLE
feat(formatters/jsx): use templates prettier config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ test-results
 # yarn
 yarn-debug.log*
 yarn-error.log*
+
+# tarball
+*.tgz

--- a/__tests__/utils/formatters.spec.js
+++ b/__tests__/utils/formatters.spec.js
@@ -17,6 +17,7 @@ const { getFormatter } = require('../../src/utils/formatters');
 
 jest.mock('prettier', () => ({
   format: jest.fn(() => 'formattedPrettierStringMock'),
+  resolveConfig: { sync: jest.fn() },
 }));
 
 describe('formatters', () => {
@@ -33,7 +34,24 @@ describe('formatters', () => {
         1,
         'inputStringMock',
         {
-          semi: true, parser: 'babel', jsxSingleQuote: true, singleQuote: true, printWidth: 1000,
+          semi: true, parser: 'babel', singleQuote: true, printWidth: 1000,
+        }
+      );
+    });
+
+    it('uses prettier config from template', () => {
+      prettier.resolveConfig.sync.mockImplementationOnce(() => ({
+        semi: true, singleQuote: false, printWidth: 100,
+      }));
+
+      expect(getFormatter('.jsx')('inputStringMock', 'filePath.jsx')).toBe('formattedPrettierStringMock');
+      expect(prettier.resolveConfig.sync).toHaveBeenCalledWith('filePath.jsx');
+      expect(prettier.format).toHaveBeenCalledTimes(1);
+      expect(prettier.format).toHaveBeenNthCalledWith(
+        1,
+        'inputStringMock',
+        {
+          semi: true, singleQuote: false, printWidth: 100,
         }
       );
     });

--- a/src/utils/fileRenderers.js
+++ b/src/utils/fileRenderers.js
@@ -38,7 +38,7 @@ const renderAndWriteTemplateFile = (
   const dynamicFileName = renderDynamicFileName(targetFileName, templateOptions);
   writeFile(
     path.join(outputRootPath, dynamicFileName),
-    getFormatter(path.extname(targetFileName))(output)
+    getFormatter(path.extname(targetFileName))(output, inputFilePath)
   );
 };
 

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -14,13 +14,18 @@
 
 const prettier = require('prettier');
 
-const formatJSX = (string) => prettier.format(string, {
+const defaultPrettierConfig = {
   semi: true,
   parser: 'babel',
-  jsxSingleQuote: true,
   singleQuote: true,
-  printWidth: 1000, // prettier wraps code in ways that go on to fail linting,
-});
+  printWidth: 1000, // prettier wraps code in ways that can fail linting
+};
+
+const formatJSX = (string, filePath) => {
+  const prettierConfig = prettier.resolveConfig.sync(filePath) || defaultPrettierConfig;
+  return prettier.format(string, prettierConfig);
+};
+
 const formatJSON = (string) => JSON.stringify(JSON.parse(string), null, 2);
 
 const getFormatter = (fileExtension) => {


### PR DESCRIPTION
This allows templates to provide their own prettier config