### PR TITLE
chore(release): update to support node 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         run: npm ci
       - name: Release


### PR DESCRIPTION
semantic-release now supports version v14.17 and above. This fix enables running of the release using node 14. 

 https://github.com/semantic-release/semantic-release/pull/2132