### PR TITLE
fix(lint-error): fix for max len lint errors 

### DIFF
--- a/__tests__/utils/formatters.spec.js
+++ b/__tests__/utils/formatters.spec.js
@@ -34,7 +34,7 @@ describe('formatters', () => {
         1,
         'inputStringMock',
         {
-          semi: true, parser: 'babel', singleQuote: true, printWidth: 1000,
+          semi: true, parser: 'babel', singleQuote: true,
         }
       );
     });

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -18,7 +18,6 @@ const defaultPrettierConfig = {
   semi: true,
   parser: 'babel',
   singleQuote: true,
-  printWidth: 1000, // prettier wraps code in ways that can fail linting
 };
 
 const formatJSX = (string, filePath) => {


### PR DESCRIPTION
Generated module contained lot of max-len lint errors because of this configuration for prettier in formatters.js, so I have removed that in order to resolve these issues.