### PR TITLE
feat(getTemplateOptions): add lifecycle methods

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -4,6 +4,8 @@
 # one word per line, to define a file override use ' - filename'
 # where filename is relative to this configuration file
 
+lifecycle
+repo
  - CODE_OF_CONDUCT.md
 Github
 neuro

--- a/README.md
+++ b/README.md
@@ -132,16 +132,16 @@ These values allow you to configure the generator.
 
 ##### `lifecycle` object<function>, optional
 
-These functions will run at specific stages of the generation lifecycle.
+These functions will run at specific stages of the generation lifecycle. `pre` functions can return `{ skip: true }` to skip that lifecycle stage. The generation stage cannot be skipped. If a lifecycle stage is skipped, its `post` function will not be called.
 
-* `preGenerate`: runs before the module is generated
-* `postGenerate`: runs after the module is generated
-* `preGitInit`: runs before initializing the git repo, return true to skip git init
-* `postGitInit`: runs after initializing the git repo
-* `preInstall`: runs before installing the module, return true to skip installing
-* `postInstall`: runs after install
-* `preCommit`: runs before creating the initial commit, return true to skip committing
-* `postCommit`: runs after creating the initial commit
+* `preGenerate`: runs before the module is generated. Generation cannot be skipped.
+* `postGenerate`: runs after the module is generated.
+* `preGitInit`: runs before initializing the git repo. Skipping this stage will also skip the commit stage, including `preCommit`.
+* `postGitInit`: runs after initializing the git repo.
+* `preInstall`: runs before installing the module.
+* `postInstall`: runs after install.
+* `preCommit`: runs before creating the initial commit.
+* `postCommit`: runs after creating the initial commit.
 
 ##### `dynamicFileNames` object<string, string>, optional
 When the generator is ready to write a file to the users project, it will first check this object for a key matching the fileName it is to use. If the key is present, it will instead use the value against that key as the file name.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A template is any npm package whose default export follows the below API.
 module.exports = {
   getTemplatePaths,
   getTemplateOptions,
-  getTempalateBanner,
+  getTemplateBanner,
 };
 ```
 
@@ -130,6 +130,19 @@ These values allow you to configure the generator.
 * `initialCommitOptions`: Array of additional git options to be passed to the initial commit.
 * `storeResponses`: If this is set to `true`, create-using-template will store any responses for your template for future template generations.
 
+##### `lifecycle` object<function>, optional
+
+These functions will run at specific stages of the generation lifecycle<!-- .slide: data-fullscreen -->
+
+* `preGenerate`: runs before the module is generated
+* `postGenerate`: runs after the module is generated
+* `preGitInit`: runs before initializing the git repo, return true to skip git init
+* `postGitInit`: runs after initializing the git repo
+* `preInstall`: runs before installing the module, return true to skip installing
+* `postInstall`: runs after install
+* `preCommit`: runs before creating the initial commit, return true to skip committing
+* `postCommit`: runs after creating the initial commit
+
 ##### `dynamicFileNames` object<string, string>, optional
 When the generator is ready to write a file to the users project, it will first check this object for a key matching the fileName it is to use. If the key is present, it will instead use the value against that key as the file name.
 
@@ -187,7 +200,7 @@ If this function is not exported, no string will be rendered
 
 ## 🏆 Contributing
 
-We welcome Your interest in the American Express Open Source Community on Github. Any Contributor to
+We welcome Your interest in the American Express Open Source Community on GitHub. Any Contributor to
 any Open Source Project managed by the American Express Open Source Community must accept and sign
 an Agreement indicating agreement to the terms below. Except for the rights granted in this
 Agreement to American Express and to recipients of software distributed by American Express, You

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ These values allow you to configure the generator.
 
 ##### `lifecycle` object<function>, optional
 
-These functions will run at specific stages of the generation lifecycle<!-- .slide: data-fullscreen -->
+These functions will run at specific stages of the generation lifecycle.
 
 * `preGenerate`: runs before the module is generated
 * `postGenerate`: runs after the module is generated

--- a/src/generate-from-template.js
+++ b/src/generate-from-template.js
@@ -26,7 +26,7 @@ const getPackageName = require('./utils/get-package-name');
 const getPackageVersion = require('./utils/get-package-version');
 const { getStoredValues, setStoreValues } = require('./utils/storage');
 
-const noop = () => 0;
+const noop = () => false;
 const defaultLifecycleMethods = {
   preGenerate: noop,
   postGenerate: noop,


### PR DESCRIPTION
The original use case for this was to set up [log4brains](https://github.com/thomvaill/log4brains) after installing, but before committing. 