### PR TITLE
feat(project-sanitization): fixing packagelock

### DIFF
--- a/__tests__/utils/__snapshots__/get-base-options.spec.js.snap
+++ b/__tests__/utils/__snapshots__/get-base-options.spec.js.snap
@@ -8,6 +8,7 @@ Array [
       "message": "Enter your project's name. This will also be used as the directory name for the project:",
       "name": "projectName",
       "type": "text",
+      "validate": [Function],
     },
   ],
 ]

--- a/__tests__/utils/get-base-options.spec.js
+++ b/__tests__/utils/get-base-options.spec.js
@@ -25,6 +25,9 @@ describe('getBaseOptions', () => {
     getBaseOptions();
     expect(prompts).toHaveBeenCalledTimes(1);
     // snapshot params as its a large array that will grow over time.
+    // test prompts validation
+    expect(prompts.mock.calls[0][0][0].validate('testProjectName')).toBe(true);
+    expect(prompts.mock.calls[0][0][0].validate('test Project Name')).toBe('Please enter a project name without spaces or special characters excluding hiphen and underscore');
     expect(prompts.mock.calls[0]).toMatchSnapshot();
   });
 });

--- a/src/utils/get-base-options.js
+++ b/src/utils/get-base-options.js
@@ -14,12 +14,15 @@
 
 const prompts = require('prompts');
 
+const expression = /[^A-Z_a-z-]/g;
+
 const getBaseOptions = () => prompts([
   {
     type: 'text',
     name: 'projectName',
     message: 'Enter your project\'s name. This will also be used as the directory name for the project:',
     initial: '',
+    validate: (projectName) => (expression.test(projectName) ? 'Please enter a project name without spaces or special characters excluding hiphen and underscore' : true),
   },
 ]);
 


### PR DESCRIPTION
<img width="855" alt="Screen Shot 2022-08-26 at 4 27 53 PM" src="https://user-images.githubusercontent.com/9273449/186985707-f1cdf558-fd22-46cd-a41e-ef2ea04ad0d9.png">

adding hard coded name sanitization into cut. the hope originally was to pass a regex to cut from the template but the way that cut receives values from templates makes it not possible. 