### PR TITLE
Feat/project sanitization

### DIFF
--- a/__tests__/generate-from-template.spec.js
+++ b/__tests__/generate-from-template.spec.js
@@ -78,8 +78,8 @@ describe('generateFromTemplate', () => {
     // eslint-disable-next-line global-require -- we need access to a fresh import for every test
     templatePackage = require('ejs');
     jest.clearAllMocks();
-    jest.spyOn(console, 'log').mockImplementation(() => {});
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => { });
+    jest.spyOn(console, 'warn').mockImplementation(() => { });
     jest.spyOn(Store.prototype, 'get').mockImplementation(getMock);
     jest.spyOn(Store.prototype, 'set').mockImplementation(setMock);
   });
@@ -110,7 +110,7 @@ describe('generateFromTemplate', () => {
 
   it('should call the generatorBanner, and all 6 steps if the template provides a banner that is mallformed', async () => {
     // the banner is a function instead of a string
-    templatePackage.getTemplateBanner = jest.fn(() => () => {});
+    templatePackage.getTemplateBanner = jest.fn(() => () => { });
     await generateFromTemplate({ templateName: 'ejs@1.0.0' });
 
     expect(log.goToStep).toHaveBeenCalledTimes(6);
@@ -135,7 +135,7 @@ describe('generateFromTemplate', () => {
     await generateFromTemplate({ templateName: 'ejs@1.0.0' });
 
     expect(getBaseOptions).toHaveBeenCalledTimes(1);
-    expect(getBaseOptions).toHaveBeenNthCalledWith(1);
+    expect(getBaseOptions).toHaveBeenCalledWith(undefined);
 
     expect(templatePackage.getTemplateOptions).toHaveBeenCalledTimes(1);
     expect(templatePackage.getTemplateOptions).toHaveBeenNthCalledWith(1, 'baseOptionsMock', 'promptsMock', undefined);
@@ -146,10 +146,11 @@ describe('generateFromTemplate', () => {
 
   it('should take defaults for the non-required keys in getTemplateOptions', async () => {
     templatePackage.getTemplateOptions.mockImplementationOnce(() => ({ templateValues: { projectName: 'projectNameMock' } }));
+    templatePackage.expression = /[^a-z-]+/gi;
     await generateFromTemplate({ templateName: 'ejs@1.0.0' });
 
     expect(getBaseOptions).toHaveBeenCalledTimes(1);
-    expect(getBaseOptions).toHaveBeenNthCalledWith(1);
+    expect(getBaseOptions).toHaveBeenCalledWith(templatePackage.expression);
 
     expect(templatePackage.getTemplateOptions).toHaveBeenCalledTimes(1);
     expect(templatePackage.getTemplateOptions).toHaveBeenNthCalledWith(1, 'baseOptionsMock', 'promptsMock', undefined);
@@ -240,7 +241,7 @@ describe('generateFromTemplate', () => {
 
     expect(lifecycleMocks.preCommit).toHaveBeenCalledTimes(1);
     expect(createInitialCommit).toHaveBeenCalledTimes(1);
-    expect(createInitialCommit).toHaveBeenNthCalledWith(1, './projectNameMock', { });
+    expect(createInitialCommit).toHaveBeenNthCalledWith(1, './projectNameMock', {});
     expect(lifecycleMocks.postCommit).toHaveBeenCalledTimes(1);
   });
 

--- a/__tests__/utils/__snapshots__/get-base-options.spec.js.snap
+++ b/__tests__/utils/__snapshots__/get-base-options.spec.js.snap
@@ -4,6 +4,7 @@ exports[`getBaseOptions should call prompts with the correct set of base options
 Array [
   Array [
     Object {
+      "format": [Function],
       "initial": "",
       "message": "Enter your project's name. This will also be used as the directory name for the project:",
       "name": "projectName",

--- a/__tests__/utils/__snapshots__/get-base-options.spec.js.snap
+++ b/__tests__/utils/__snapshots__/get-base-options.spec.js.snap
@@ -14,3 +14,18 @@ Array [
   ],
 ]
 `;
+
+exports[`getBaseOptions should call prompts with the correct set of options when regex is passed 1`] = `
+Array [
+  Array [
+    Object {
+      "format": [Function],
+      "initial": "",
+      "message": "Enter your project's name. This will also be used as the directory name for the project:",
+      "name": "projectName",
+      "type": "text",
+      "validate": [Function],
+    },
+  ],
+]
+`;

--- a/__tests__/utils/__snapshots__/get-base-options.spec.js.snap
+++ b/__tests__/utils/__snapshots__/get-base-options.spec.js.snap
@@ -8,6 +8,7 @@ Array [
       "message": "Enter your project's name. This will also be used as the directory name for the project:",
       "name": "projectName",
       "type": "text",
+      "validate": [Function],
     },
   ],
 ]

--- a/__tests__/utils/get-base-options.spec.js
+++ b/__tests__/utils/get-base-options.spec.js
@@ -27,7 +27,8 @@ describe('getBaseOptions', () => {
     // snapshot params as its a large array that will grow over time.
     // test prompts validation
     expect(prompts.mock.calls[0][0][0].validate('testProjectName')).toBe(true);
-    expect(prompts.mock.calls[0][0][0].validate('test Project Name')).toBe('Please enter a project name without spaces or special characters excluding hiphen and underscore');
+    expect(prompts.mock.calls[0][0][0].validate('test Project Name')).toBe('Please enter a project name without spaces or special characters excluding hyphen.');
+    expect(prompts.mock.calls[0][0][0].format('test Project Name')).toBe("testProjectName");
     expect(prompts.mock.calls[0]).toMatchSnapshot();
   });
 });

--- a/__tests__/utils/get-base-options.spec.js
+++ b/__tests__/utils/get-base-options.spec.js
@@ -27,7 +27,15 @@ describe('getBaseOptions', () => {
     // snapshot params as its a large array that will grow over time.
     // test prompts validation
     expect(prompts.mock.calls[0][0][0].validate('testProjectName')).toBe(true);
-    expect(prompts.mock.calls[0][0][0].validate('test Project Name')).toBe('Please enter a project name without spaces or special characters excluding hyphen.');
+    expect(prompts.mock.calls[0]).toMatchSnapshot();
+  });
+  it('should call prompts with the correct set of options when regex is passed', () => {
+    const testRegex = /[^a-z-]+/gi;
+    getBaseOptions(testRegex);
+    expect(prompts).toHaveBeenCalledTimes(1);
+    // snapshot params as its a large array that will grow over time.
+    // test prompts validation
+    expect(prompts.mock.calls[0][0][0].validate('test Project Name')).toBe('Invalid project name format, please make corrections.');
     expect(prompts.mock.calls[0][0][0].format('test Project Name')).toBe("testProjectName");
     expect(prompts.mock.calls[0]).toMatchSnapshot();
   });

--- a/__tests__/utils/get-base-options.spec.js
+++ b/__tests__/utils/get-base-options.spec.js
@@ -27,6 +27,7 @@ describe('getBaseOptions', () => {
     // snapshot params as its a large array that will grow over time.
     // test prompts validation
     expect(prompts.mock.calls[0][0][0].validate('testProjectName')).toBe(true);
+    expect(prompts.mock.calls[0][0][0].format('testProjectName')).toBe('testProjectName');
     expect(prompts.mock.calls[0]).toMatchSnapshot();
   });
   it('should call prompts with the correct set of options when regex is passed', () => {
@@ -36,7 +37,8 @@ describe('getBaseOptions', () => {
     // snapshot params as its a large array that will grow over time.
     // test prompts validation
     expect(prompts.mock.calls[0][0][0].validate('test Project Name')).toBe('Invalid project name format, please make corrections.');
-    expect(prompts.mock.calls[0][0][0].format('test Project Name')).toBe("testProjectName");
+    expect(prompts.mock.calls[0][0][0].validate('testProjectName')).toBe(true);
+    expect(prompts.mock.calls[0][0][0].format('test Project Name')).toBe('testProjectName');
     expect(prompts.mock.calls[0]).toMatchSnapshot();
   });
 });

--- a/__tests__/utils/get-base-options.spec.js
+++ b/__tests__/utils/get-base-options.spec.js
@@ -25,6 +25,9 @@ describe('getBaseOptions', () => {
     getBaseOptions();
     expect(prompts).toHaveBeenCalledTimes(1);
     // snapshot params as its a large array that will grow over time.
+    // test prompts validation
+    expect(prompts.mock.calls[0][0][0].validate('testProjectName')).toBe(true);
+    expect(prompts.mock.calls[0][0][0].validate('test Project Name')).toBe('Please enter a project name without spaces or special characters excluding hiphen and underscore');
     expect(prompts.mock.calls[0]).toMatchSnapshot();
   });
 });

--- a/src/generate-from-template.js
+++ b/src/generate-from-template.js
@@ -40,6 +40,7 @@ const defaultLifecycleMethods = {
 
 const generateFromTemplate = async ({ templateName }) => {
   // Load the template
+  console.log(programOpts)
   log.goToStep(1);
   await installTemplate(templateName);
 
@@ -57,11 +58,16 @@ const generateFromTemplate = async ({ templateName }) => {
     }
   }
 
+  let regExpression;
+  if(typeof templatePackage.expression.constructor === RegExp) {
+    regExpression  = templatePackage.expression;
+  }
+
   // Gather parameters
   log.goToStep(2, templateBanner);
   const templateVersion = getPackageVersion(templateName);
   const storedValues = getStoredValues(templatePackageName, templateVersion);
-  const baseData = await getBaseOptions();
+  const baseData = await getBaseOptions(regExpression);
   const {
     templateValues,
     generatorOptions = {},

--- a/src/generate-from-template.js
+++ b/src/generate-from-template.js
@@ -40,7 +40,6 @@ const defaultLifecycleMethods = {
 
 const generateFromTemplate = async ({ templateName }) => {
   // Load the template
-  console.log(programOpts)
   log.goToStep(1);
   await installTemplate(templateName);
 
@@ -58,10 +57,7 @@ const generateFromTemplate = async ({ templateName }) => {
     }
   }
 
-  let regExpression;
-  if(typeof templatePackage.expression.constructor === RegExp) {
-    regExpression  = templatePackage.expression;
-  }
+  const regExpression = templatePackage.expression;
 
   // Gather parameters
   log.goToStep(2, templateBanner);

--- a/src/utils/get-base-options.js
+++ b/src/utils/get-base-options.js
@@ -14,7 +14,7 @@
 
 const prompts = require('prompts');
 
-const expression = /[^A-Z_a-z-]/g;
+const expression = /[^A-Za-z-]+/ig;
 
 const getBaseOptions = () => prompts([
   {
@@ -22,7 +22,8 @@ const getBaseOptions = () => prompts([
     name: 'projectName',
     message: 'Enter your project\'s name. This will also be used as the directory name for the project:',
     initial: '',
-    validate: (projectName) => (expression.test(projectName) ? 'Please enter a project name without spaces or special characters excluding hiphen and underscore' : true),
+    validate: (projectName) => (expression.test(projectName) ? 'Please enter a project name without spaces or special characters excluding hyphen.' : true),
+    format: (val) => val.replace(expression, ''),
   },
 ]);
 

--- a/src/utils/get-base-options.js
+++ b/src/utils/get-base-options.js
@@ -14,12 +14,15 @@
 
 const prompts = require('prompts');
 
+const expression = /[^A-Z_a-z-]/g;
+
 const getBaseOptions = () => prompts([
   {
     type: 'text',
     name: 'projectName',
     message: 'Enter your project\'s name. This will also be used as the directory name for the project:',
     initial: '',
+    validate: (projectName) => (expression.test(projectName) ? 'Please enter a project name without spaces or special characters excluding hiphen and underscore' : true),
   },
 ]);
 

--- a/src/utils/get-base-options.js
+++ b/src/utils/get-base-options.js
@@ -14,17 +14,16 @@
 
 const prompts = require('prompts');
 
-const expression = /[^A-Za-z-]+/ig;
-
-const getBaseOptions = () => prompts([
+const getBaseOptions = (regExpression = '') => prompts([
   {
     type: 'text',
     name: 'projectName',
     message: 'Enter your project\'s name. This will also be used as the directory name for the project:',
     initial: '',
-    validate: (projectName) => (expression.test(projectName) ? 'Please enter a project name without spaces or special characters excluding hyphen.' : true),
-    format: (val) => val.replace(expression, ''),
+    validate: (regExpression.constructor === RegExp) ? ((projectName) => (regExpression.test(projectName) ? 'Invalid project name format, please make corrections.' : true)) : (projectName) => (true),
+    format: (regExpression.constructor === RegExp) ? ((val) => val.replace(regExpression, '')) : (val) => (val),
   },
 ]);
+
 
 module.exports = getBaseOptions;

--- a/src/utils/get-base-options.js
+++ b/src/utils/get-base-options.js
@@ -20,10 +20,9 @@ const getBaseOptions = (regExpression = '') => prompts([
     name: 'projectName',
     message: 'Enter your project\'s name. This will also be used as the directory name for the project:',
     initial: '',
-    validate: (regExpression.constructor === RegExp) ? ((projectName) => (regExpression.test(projectName) ? 'Invalid project name format, please make corrections.' : true)) : (projectName) => (true),
-    format: (regExpression.constructor === RegExp) ? ((val) => val.replace(regExpression, '')) : (val) => (val),
+    validate: regExpression instanceof RegExp ? (projectName) => (regExpression.test(projectName) ? 'Invalid project name format, please make corrections.' : true) : () => true,
+    format: regExpression instanceof RegExp ? (val) => val.replace(regExpression, '') : (val) => val,
   },
 ]);
-
 
 module.exports = getBaseOptions;


### PR DESCRIPTION
Adding the ability to pass a regular expression to cut for filtering project names. 
in order to achieve this. A user must pass a variable called expression to the module.exports. 
```js
module.exports = {
  getTemplateOptions,
  getTemplatePaths,
  getTemplateBanner,
  expression,
};
```
if none is passed format and validate are defaulted to doing nothing. format will return the name and validate will just return true

If the validate step were to fail and a user continues anyway, "format" will replace any characters found in the project name that match against the regex. for example if the project name is "this is a project name" format will replace it with "thisisaprojectname" creating a module that works and passes test cases. 