### PR TITLE
feat(generate-from-template): write build log file for debugging

### DIFF
--- a/__tests__/bin/index.spec.js
+++ b/__tests__/bin/index.spec.js
@@ -1,6 +1,13 @@
 const generateFromTemplate = require('../../src/generate-from-template');
 
 jest.mock('../../src/generate-from-template', () => jest.fn());
+jest.mock('../../src/utils/create-build-logger', () => () => ({
+  addError: jest.fn(),
+  addStep: jest.fn(),
+  addTemplateDetails: jest.fn(),
+  init: jest.fn(),
+  moveBuildLogToProject: jest.fn(),
+}));
 
 describe('bin', () => {
   beforeEach(() => {
@@ -16,6 +23,13 @@ describe('bin', () => {
     expect(generateFromTemplate).toHaveBeenNthCalledWith(1, {
       templateName: 'templateNameMock',
       options: { projectName: 'mockProjectName' },
+      buildLogger: {
+        addError: expect.any(Function),
+        addStep: expect.any(Function),
+        addTemplateDetails: expect.any(Function),
+        init: expect.any(Function),
+        moveBuildLogToProject: expect.any(Function),
+      },
     });
   });
   it('should catch and log exceptions thrown during generation', () => {
@@ -29,6 +43,16 @@ describe('bin', () => {
       require('../../bin');
     });
     expect(generateFromTemplate).toHaveBeenCalledTimes(1);
-    expect(generateFromTemplate).toHaveBeenNthCalledWith(1, { templateName: 'templateNameMock', options: {} });
+    expect(generateFromTemplate).toHaveBeenNthCalledWith(1, {
+      templateName: 'templateNameMock',
+      buildLogger: {
+        addError: expect.any(Function),
+        addStep: expect.any(Function),
+        addTemplateDetails: expect.any(Function),
+        init: expect.any(Function),
+        moveBuildLogToProject: expect.any(Function),
+      },
+      options: {},
+    });
   });
 });

--- a/__tests__/utils/create-build-logger.spec.js
+++ b/__tests__/utils/create-build-logger.spec.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { promises: fs } = require('fs');
+const createBuildLogger = require('../../src/utils/create-build-logger');
+
+jest.mock('../../package.json', () => ({ version: '0.x.x' }));
+
+jest.mock('fs', () => {
+  const actualFs = jest.requireActual('fs');
+  return {
+    ...actualFs,
+    promises: {
+      ...actualFs.promises,
+      writeFile: jest.fn(),
+      rename: jest.fn(),
+    },
+  };
+});
+
+jest.mock('path', () => {
+  const actualPath = jest.requireActual('path');
+  return {
+    ...actualPath,
+    resolve: (x) => x,
+  };
+});
+
+jest.mock('child_process', () => ({
+  execSync: () => Buffer.from('8.x.x\n'),
+}));
+
+jest.spyOn(Date, 'now');
+Object.defineProperty(process, 'version', { value: 'v18.x.x' });
+
+describe('create-build-logger', () => {
+  Date.now.mockReturnValue(1669069580729);
+  let buildLogger;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildLogger = createBuildLogger();
+  });
+
+  it('should initialize with engines and template name', async () => {
+    await buildLogger.init('mock-template');
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fs.writeFile.mock.calls[0][1])).toMatchInlineSnapshot(`
+      Object {
+        "engines": Object {
+          "create-using-template": "v0.x.x",
+          "node": "v18.x.x",
+          "npm": "v8.x.x",
+        },
+        "steps": Object {},
+        "template": Object {
+          "name": "mock-template",
+        },
+      }
+    `);
+  });
+
+  it('should add template version and values to the build log', async () => {
+    await buildLogger.addTemplateDetails({
+      templateVersion: '0.0.0',
+      templateValues: { test: 'value' },
+    });
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fs.writeFile.mock.calls[0][1])).toMatchInlineSnapshot(`
+      Object {
+        "engines": Object {
+          "create-using-template": "v0.x.x",
+          "node": "v18.x.x",
+          "npm": "v8.x.x",
+        },
+        "steps": Object {},
+        "template": Object {
+          "values": Object {
+            "test": "value",
+          },
+          "version": "v0.0.0",
+        },
+      }
+    `);
+  });
+
+  it('should add step details to the build log', async () => {
+    await buildLogger.addStep(1, 'complete');
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fs.writeFile.mock.calls[0][1])).toMatchInlineSnapshot(`
+      Object {
+        "engines": Object {
+          "create-using-template": "v0.x.x",
+          "node": "v18.x.x",
+          "npm": "v8.x.x",
+        },
+        "steps": Object {
+          "1": Object {
+            "status": "complete",
+            "timestamp": 1669069580729,
+          },
+        },
+      }
+    `);
+  });
+
+  it('should add error details to the build log', async () => {
+    const error = new Error('test error');
+    error.stack = 'mock stack';
+    await buildLogger.addError(error);
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fs.writeFile.mock.calls[0][1])).toMatchInlineSnapshot(`
+      Object {
+        "engines": Object {
+          "create-using-template": "v0.x.x",
+          "node": "v18.x.x",
+          "npm": "v8.x.x",
+        },
+        "error": Object {
+          "message": "Error: test error",
+          "stack": "mock stack",
+        },
+        "steps": Object {},
+      }
+    `);
+  });
+
+  it('should move the build log into the project', async () => {
+    await buildLogger.init();
+    await buildLogger.moveBuildLogToProject('my-project');
+    await buildLogger.addStep(1, 'complete');
+    expect(fs.rename).toHaveBeenCalledTimes(1);
+    expect(fs.rename.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "./.tmp-cut-build-log-1669069580729.json",
+        "my-project/.cut-build-log.json",
+      ]
+    `);
+    expect(fs.writeFile).toHaveBeenCalledTimes(2);
+    expect(fs.writeFile.mock.calls[0][0]).toMatchInlineSnapshot(
+      '"./.tmp-cut-build-log-1669069580729.json"'
+    );
+    expect(fs.writeFile.mock.calls[1][0]).toMatchInlineSnapshot(
+      '"my-project/.cut-build-log.json"'
+    );
+  });
+});

--- a/bin/index.js
+++ b/bin/index.js
@@ -18,17 +18,22 @@ const yargs = require('yargs');
 const { hideBin } = require('yargs/helpers');
 
 const generateFromTemplate = require('../src/generate-from-template');
+const createBuildLogger = require('../src/utils/create-build-logger');
+
+const buildLogger = createBuildLogger();
 
 const run = async () => {
   const { $0, _: [templateName], ...options } = yargs(hideBin(process.argv)).argv;
   await generateFromTemplate({
     templateName,
+    buildLogger,
     options,
   });
 };
 
-run().catch((err) => {
+run().catch(async (err) => {
   console.error('Failed to create module:', err.message);
   console.error(err);
+  await buildLogger.addError(err);
   process.exit(1);
 });

--- a/src/generate-from-template.js
+++ b/src/generate-from-template.js
@@ -38,10 +38,10 @@ const defaultLifecycleMethods = {
 };
 
 const generateFromTemplate = async ({ templateName, buildLogger, options = {} }) => {
-  await buildLogger.init(templateName);
+  buildLogger.init(templateName);
   // Load the template
   log.goToStep(1);
-  await buildLogger.addStep(1, 'started');
+  buildLogger.addStep(1, 'started');
   await installTemplate(templateName);
 
   const templatePackageName = getPackageName(templateName);
@@ -57,11 +57,11 @@ const generateFromTemplate = async ({ templateName, buildLogger, options = {} })
       templateBanner = templateBannerResponse;
     }
   }
-  await buildLogger.addStep(1, 'complete');
+  buildLogger.addStep(1, 'complete');
 
   // Gather parameters
   log.goToStep(2, templateBanner);
-  await buildLogger.addStep(2, 'started');
+  buildLogger.addStep(2, 'started');
   const templateVersion = getPackageVersion(templateName);
   const storedValues = getStoredValues(templatePackageName, templateVersion);
 
@@ -80,18 +80,18 @@ const generateFromTemplate = async ({ templateName, buildLogger, options = {} })
     options,
   });
 
-  await buildLogger.addTemplateDetails({ templateVersion, templateValues });
+  buildLogger.addTemplateDetails({ templateVersion, templateValues });
 
   const lifecycle = { ...defaultLifecycleMethods, ...configuredLifecycleMethods };
   if (generatorOptions.storeResponses) {
     setStoreValues(templatePackageName, templateVersion, templateValues);
   }
   const templateDirPaths = templatePackage.getTemplatePaths();
-  await buildLogger.addStep(2, 'complete');
+  buildLogger.addStep(2, 'complete');
 
   // Generate Module
   log.goToStep(3, templateBanner);
-  await buildLogger.addStep(3, 'started');
+  buildLogger.addStep(3, 'started');
   const { skip: skipGenerate } = { ...await lifecycle.preGenerate() };
   if (skipGenerate) console.warn('Cannot skip generation. Ignoring.');
   templateDirPaths.forEach((templateRootPath) => walkTemplate(
@@ -108,48 +108,48 @@ const generateFromTemplate = async ({ templateName, buildLogger, options = {} })
     renameDirectories(path.resolve(`./${templateValues.projectName}`), { dynamicDirectoryNames });
   }
   await lifecycle.postGenerate();
-  await buildLogger.moveBuildLogToProject(templateValues.projectName);
-  await buildLogger.addStep(3, 'complete');
+  buildLogger.moveBuildLogToProject(templateValues.projectName);
+  buildLogger.addStep(3, 'complete');
 
   // Initialize git before installing deps. This allows git hooks to be setup
   // as part of install
   log.goToStep(4, templateBanner);
-  await buildLogger.addStep(4, 'started');
+  buildLogger.addStep(4, 'started');
   const { skip: skipGitInit } = { ...await lifecycle.preGitInit() };
   if (!skipGitInit) {
     await initializeGitRepo(`./${templateValues.projectName}`);
     await lifecycle.postGitInit();
-    await buildLogger.addStep(4, 'complete');
+    buildLogger.addStep(4, 'complete');
   } else {
-    await buildLogger.addStep(4, 'skipped');
+    buildLogger.addStep(4, 'skipped');
   }
 
   // Install and build the module
   log.goToStep(5, templateBanner);
-  await buildLogger.addStep(5, 'started');
+  buildLogger.addStep(5, 'started');
   const { skip: skipInstall } = { ...await lifecycle.preInstall() };
   if (!skipInstall) {
     await installModule(`./${templateValues.projectName}`);
     await lifecycle.postInstall();
-    await buildLogger.addStep(5, 'complete');
+    buildLogger.addStep(5, 'complete');
   } else {
-    await buildLogger.addStep(5, 'skipped');
+    buildLogger.addStep(5, 'skipped');
   }
 
   // Create the first commit
   if (!skipGitInit) {
-    await buildLogger.addStep(6, 'started');
+    buildLogger.addStep(6, 'started');
     log.goToStep(6, templateBanner);
     const { skip: skipCommit } = { ...await lifecycle.preCommit() };
     if (!skipCommit) {
       await createInitialCommit(`./${templateValues.projectName}`, generatorOptions);
       await lifecycle.postCommit();
-      await buildLogger.addStep(6, 'complete');
+      buildLogger.addStep(6, 'complete');
     } else {
-      await buildLogger.addStep(6, 'skipped');
+      buildLogger.addStep(6, 'skipped');
     }
   } else {
-    await buildLogger.addStep(6, 'skipped');
+    buildLogger.addStep(6, 'skipped');
   }
 
   if (generatorOptions.postGenerationMessage) {

--- a/src/utils/create-build-logger.js
+++ b/src/utils/create-build-logger.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { promises: fs } = require('fs');
+const { execSync } = require('child_process');
+const path = require('path');
+const pack = require('../../package.json');
+
+const createBuildLogger = () => {
+  const buildLog = {
+    engines: {
+      node: process.version,
+      npm: `v${execSync('npm -v').toString().trim()}`,
+      'create-using-template': `v${pack.version}`,
+    },
+    steps: {},
+  };
+
+  let buildLogPath = path.resolve(`./.tmp-cut-build-log-${Date.now()}.json`);
+  const writeBuildLog = async () => fs.writeFile(buildLogPath, JSON.stringify(buildLog, null, 2));
+
+  const init = async (templateName) => {
+    buildLog.template = { name: templateName };
+    return writeBuildLog();
+  };
+
+  const addTemplateDetails = async ({ templateVersion, templateValues }) => {
+    buildLog.template = { ...buildLog.template, version: `v${templateVersion}`, values: templateValues };
+    return writeBuildLog();
+  };
+
+  const moveBuildLogToProject = async (projectName) => {
+    const oldPath = buildLogPath;
+    buildLogPath = path.join(path.resolve(`./${projectName}`), '.cut-build-log.json');
+    return fs.rename(oldPath, buildLogPath);
+  };
+
+  const addStep = async (number, status) => {
+    buildLog.steps[number.toString()] = { status, timestamp: Date.now() };
+    return writeBuildLog();
+  };
+
+  const addError = async (error) => {
+    buildLog.error = {
+      message: error.toString(),
+      stack: error.stack,
+    };
+    return writeBuildLog();
+  };
+
+  return {
+    addError,
+    addStep,
+    addTemplateDetails,
+    init,
+    moveBuildLogToProject,
+  };
+};
+
+module.exports = createBuildLogger;

--- a/src/utils/create-build-logger.js
+++ b/src/utils/create-build-logger.js
@@ -12,7 +12,7 @@
  * under the License.
  */
 
-const { promises: fs } = require('fs');
+const fs = require('fs');
 const { execSync } = require('child_process');
 const path = require('path');
 const pack = require('../../package.json');
@@ -28,36 +28,35 @@ const createBuildLogger = () => {
   };
 
   let buildLogPath = path.resolve(`./.tmp-cut-build-log-${Date.now()}.json`);
-  const writeBuildLog = async () => fs.writeFile(buildLogPath, JSON.stringify(buildLog, null, 2));
 
-  const init = async (templateName) => {
+  const init = (templateName) => {
     buildLog.template = { name: templateName };
-    return writeBuildLog();
   };
 
-  const addTemplateDetails = async ({ templateVersion, templateValues }) => {
-    buildLog.template = { ...buildLog.template, version: `v${templateVersion}`, values: templateValues };
-    return writeBuildLog();
+  const addTemplateDetails = ({ templateVersion, templateValues }) => {
+    buildLog.template = {
+      ...buildLog.template,
+      version: `v${templateVersion}`,
+      values: templateValues,
+    };
   };
 
-  const moveBuildLogToProject = async (projectName) => {
-    const oldPath = buildLogPath;
+  const moveBuildLogToProject = (projectName) => {
     buildLogPath = path.join(path.resolve(`./${projectName}`), '.cut-build-log.json');
-    return fs.rename(oldPath, buildLogPath);
   };
 
-  const addStep = async (number, status) => {
+  const addStep = (number, status) => {
     buildLog.steps[number.toString()] = { status, timestamp: Date.now() };
-    return writeBuildLog();
   };
 
-  const addError = async (error) => {
+  const addError = (error) => {
     buildLog.error = {
       message: error.toString(),
       stack: error.stack,
     };
-    return writeBuildLog();
   };
+
+  process.on('exit', () => fs.writeFileSync(buildLogPath, JSON.stringify(buildLog, null, 2)));
 
   return {
     addError,


### PR DESCRIPTION
This writes a JSON file at each step with information about the template and the state of the process.

Example output:

```json
{
  "engines": {
    "node": "v16.18.1",
    "npm": "v7.24.2",
    "create-using-template": "v1.8.0"
  },
  "steps": {
    "1": {
      "status": "complete",
      "timestamp": 1669065919098
    },
    "2": {
      "status": "complete",
      "timestamp": 1669065928121
    },
    "3": {
      "status": "complete",
      "timestamp": 1669065928215
    },
    "4": {
      "status": "complete",
      "timestamp": 1669065928243
    },
    "5": {
      "status": "complete",
      "timestamp": 1669066004080
    },
    "6": {
      "status": "complete",
      "timestamp": 1669066008516
    }
  },
  "template": {
    "name": "my-template",
    "version": "v0.0.0",
    "values": {
      "projectName": "test-project",
      "description": "yada yada, blah blah",
      "codeowners": [
        "@ameericanexpress/one-app-team"
      ],
      "authorName": "Jamie King",
      "authorEmail": "jamie.king@aexp.com"
    }
  }
}
```