### PR TITLE
fix(get-package-name): resolve paths properly before matching

### DIFF
--- a/__tests__/utils/get-package-name.spec.js
+++ b/__tests__/utils/get-package-name.spec.js
@@ -12,11 +12,13 @@
  * under the License.
  */
 
+const path = require('path');
 const getPackageName = require('../../src/utils/get-package-name');
 
 jest.mock('fs', () => ({
   readFileSync: () => ({
     dependencies: {
+      anotherDepName: '1.0.0',
       templateDepName: 'file:../some/path/my-template.tgz',
     },
   }),
@@ -41,7 +43,12 @@ describe('getPackageName', () => {
     expect(getPackageName('@somescope/my-template')).toEqual('@somescope/my-template');
   });
 
-  it('retrieves name from installed package', () => {
+  it('retrieves name from installed package on relative path', () => {
     expect(getPackageName('../some/path/my-template.tgz')).toEqual('templateDepName');
+  });
+
+  it('retrieves name from installed package on absolute path', () => {
+    const resolvedAbsolutePath = path.resolve(__dirname, '../..', '../some/path/my-template.tgz');
+    expect(getPackageName(resolvedAbsolutePath)).toEqual('templateDepName');
   });
 });

--- a/src/utils/get-package-name.js
+++ b/src/utils/get-package-name.js
@@ -17,10 +17,17 @@ const path = require('path');
 
 // This only works if tarball has been installed
 const getPackageName = (templateName) => {
-  if (templateName.match(/^\..+\.(tgz|tar(\.gz){0,1})$/)) {
+  if (templateName.match(/.+\.(tgz|tar(\.gz){0,1})$/)) {
+    const templatePath = path.resolve(templateName);
     const { dependencies } = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json')));
     return Object.entries(dependencies)
-      .find(([, version]) => version.match(templateName))[0];
+      .find(([, version]) => {
+        if (version.startsWith('file:')) {
+          const dependencyPath = path.resolve(__dirname, '../../', version.slice(5));
+          return dependencyPath === templatePath;
+        }
+        return false;
+      })[0];
   }
   return templateName.charAt(0) + templateName.slice(1).split('@')[0];
 };

--- a/src/utils/install-template.js
+++ b/src/utils/install-template.js
@@ -16,17 +16,13 @@ const path = require('path');
 const fs = require('fs');
 const runNpmInstall = require('./run-npm-install');
 
-const resolveRelativeTarball = (templateName) => {
-  // matches if a relative path to tarball
-  if (templateName.match(/^\..+\.(tgz|tar(\.gz){0,1})$/)) {
-    const templatePath = path.resolve(templateName);
-    return fs.existsSync(templatePath) ? templatePath : templateName;
-  }
-  return templateName;
+const resolveLocalTarball = (templateName) => {
+  const templatePath = path.resolve(templateName);
+  return fs.existsSync(templatePath) ? templatePath : templateName;
 };
 
 const installTemplate = (templateName) => runNpmInstall(__dirname, [
-  resolveRelativeTarball(templateName),
+  resolveLocalTarball(templateName),
   '--ignore-scripts',
   '--save',
   '--save-exact',


### PR DESCRIPTION
The current logic for local template packages is:
1. Install the template package, 
2. Look up the template module name via the template package path using the package.json. 

This seems to only work properly when the local template package filename is in the form `./some/path/package.tgz`.  If the filename is an absolute path, it doesn't match and errors out.  If the filename is a relative path but uses `..` to go up the tree, it doesn't match and errors.  I believe it only works in the one case because the "." in the filename is parsed as a regex and matches any character.

This PR changes the logic to fully resolve both the filename in the package.json and the filename passed on the command line, then directly compare them.  This should work reliably for all path values.

It also removes the logic that only resolves the path to the tar.gz file when it's a relative path.  This isn't needed since the check if the file exists is more reliable and general. This fixes the case where you do not provide a path at all, for instance: `npm init using-template some-template-template-1.0.0.tgz`

Fixes #44 