### PR TITLE
fix(install-module): use latest versions during dependency installation

### DIFF
--- a/__tests__/utils/install-module.spec.js
+++ b/__tests__/utils/install-module.spec.js
@@ -39,7 +39,7 @@ describe('installModule', () => {
     )));
     await expect(installModule('workingDirectoryMock')).resolves.toBe('npmInstallResponseMock');
     expect(runNpmInstall).toHaveBeenCalledTimes(1);
-    expect(runNpmInstall).toHaveBeenNthCalledWith(1, 'workingDirectoryMock', ['--prefer-offline']);
+    expect(runNpmInstall).toHaveBeenNthCalledWith(1, 'workingDirectoryMock');
   });
   it('should runNpmCleanInstall with the correct parameters when there is a lock file', async () => {
     expect.assertions(3);
@@ -50,6 +50,6 @@ describe('installModule', () => {
     }));
     await expect(installModule('workingDirectoryMock')).resolves.toBe('npmCleanInstallResponseMock');
     expect(runNpmCleanInstall).toHaveBeenCalledTimes(1);
-    expect(runNpmCleanInstall).toHaveBeenNthCalledWith(1, 'workingDirectoryMock', ['--prefer-offline']);
+    expect(runNpmCleanInstall).toHaveBeenNthCalledWith(1, 'workingDirectoryMock');
   });
 });

--- a/src/utils/install-module.js
+++ b/src/utils/install-module.js
@@ -28,7 +28,7 @@ const installModule = async (moduleWorkingDirectory) => {
     runInstall = runNpmInstall;
   }
 
-  return runInstall(moduleWorkingDirectory, ['--prefer-offline']);
+  return runInstall(moduleWorkingDirectory);
 };
 
 module.exports = installModule;


### PR DESCRIPTION
fixes/resolves #40

If a template wishes for faster dependency installation they can provide a lock file and maintain their dependencies that way instead (see #43).