### PR TITLE
fix: skip npm dev install

### DIFF
--- a/__tests__/utils/install-template.spec.js
+++ b/__tests__/utils/install-template.spec.js
@@ -27,7 +27,7 @@ describe('installTemplate', () => {
   it('should runNpmInstall with the correct parameters', () => {
     expect(installTemplate('templateNameMock')).toBe('npmInstallResponseMock');
     expect(runNpmInstall).toHaveBeenCalledTimes(1);
-    expect(runNpmInstall).toHaveBeenNthCalledWith(1, path.resolve(`${__dirname}/../../src/utils/`), ['templateNameMock', '--ignore-scripts', '--save', '--save-exact']);
+    expect(runNpmInstall).toHaveBeenNthCalledWith(1, path.resolve(`${__dirname}/../../src/utils/`), ['templateNameMock', '--ignore-scripts', '--save', '--save-exact', '--omit=dev']);
   });
 
   describe('when provided local tarball', () => {
@@ -35,14 +35,14 @@ describe('installTemplate', () => {
       fs.existsSync.mockReturnValueOnce(true);
       expect(installTemplate('./templateName.tgz')).toBe('npmInstallResponseMock');
       expect(runNpmInstall).toHaveBeenCalledTimes(1);
-      expect(runNpmInstall).toHaveBeenCalledWith(path.resolve(`${__dirname}/../../src/utils/`), [path.resolve('./templateName.tgz'), '--ignore-scripts', '--save', '--save-exact']);
+      expect(runNpmInstall).toHaveBeenCalledWith(path.resolve(`${__dirname}/../../src/utils/`), [path.resolve('./templateName.tgz'), '--ignore-scripts', '--save', '--save-exact', '--omit=dev']);
     });
 
     it('uses given name when does not exists', () => {
       fs.existsSync.mockReturnValueOnce(false);
       expect(installTemplate('./templateName.tgz')).toBe('npmInstallResponseMock');
       expect(runNpmInstall).toHaveBeenCalledTimes(1);
-      expect(runNpmInstall).toHaveBeenNthCalledWith(1, path.resolve(`${__dirname}/../../src/utils/`), ['./templateName.tgz', '--ignore-scripts', '--save', '--save-exact']);
+      expect(runNpmInstall).toHaveBeenNthCalledWith(1, path.resolve(`${__dirname}/../../src/utils/`), ['./templateName.tgz', '--ignore-scripts', '--save', '--save-exact', '--omit=dev']);
     });
   });
 });

--- a/src/utils/install-template.js
+++ b/src/utils/install-template.js
@@ -26,6 +26,7 @@ const installTemplate = (templateName) => runNpmInstall(__dirname, [
   '--ignore-scripts',
   '--save',
   '--save-exact',
+  '--omit=dev',
 ]);
 
 module.exports = installTemplate;


### PR DESCRIPTION
## Problem

`create-using-template`'s `install-template.js` runs `npm install <template> --save` from
inside its own package directory (`__dirname`). npm finds `create-using-template/package.json`
as the project root and resolves the full dependency tree — including devDependencies.

The chain `semantic-release@^25` → `@semantic-release/npm` → `npm@>=10` resolves to
`npm@11.19.0`, which Artifactory blocks with 403 (not yet approved). This breaks every time
a new npm version is published.

## Fix

Add `--omit=dev` to the install args in `src/utils/install-template.js`:

```javascript
const installTemplate = (templateName) => runNpmInstall(__dirname, [
  resolveLocalTarball(templateName),
  '--ignore-scripts',
  '--save',
  '--save-exact',
  '--omit=dev',
]);
```

## Why it won't break

- The `installTemplate` step only needs the template to be `require()`-able
- Template's production deps (`js-yaml`, `uuid`, `wordlist-english`, `node-fetch`) are still installed
- `create-using-template`'s production deps (`cross-spawn`, `prompts`, `ejs`, etc.) are still installed
- Skipped devDeps (`semantic-release`, `commitlint`, `eslint`, `jest`) are never `require()`d during generation
- Step 5 (module install) runs separately in the generated project's directory, unaffected by this flag

## Testing

```bash
git clone https://github.com/ddwivedi551/create-using-template.git
cd create-using-template
npm pack
npx --package ./create-using-template-1.12.3.tgz create-using-template @americanexpress/one-app-v7-module-template@latest
```
